### PR TITLE
Update poetry to v1.4.0

### DIFF
--- a/poetry/Dockerfile
+++ b/poetry/Dockerfile
@@ -1,8 +1,8 @@
 FROM openstax/python3-base:latest as base
 
-ENV POETRY_VERSION 1.1.7
+ENV POETRY_VERSION 1.4.0
 
 # install poetry
 # keep this in sync with the version in pyproject.toml and Dockerfile
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-ENV PATH "/root/.poetry/bin:/opt/venv/bin:${PATH}"
+RUN curl -sSL https://install.python-poetry.org | python -
+ENV PATH "/root/.local/bin:/opt/venv/bin:${PATH}"


### PR DESCRIPTION
New install script, new install path, new deprecated options.

The --no-dev option is deprecated in this version. Instead, we should use --only main.


I will also need to make sure everything that uses this image is using a pinned version.  While everything should still be backwards compatible, but it is best to be safe.