### PR TITLE
Update poetry to 1.4.0

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -29,7 +29,7 @@ RUN echo "${TZ}" > /etc/timezone \
 #===============
 # Install poetry
 #===============
-ENV POETRY_VERSION 1.1.7
+ENV POETRY_VERSION 1.4.0
 # install poetry
 # keep this in sync with the version in pyproject.toml and Dockerfile
 RUN curl -sSL https://install.python-poetry.org | python3 -


### PR DESCRIPTION
Same as version in poetry/Dockerfile

This image is used by backend tests image in CORGI. It [looks like that is the only place it is used](https://github.com/search?q=org%3Aopenstax+openstax%2Fubuntu-20.04&type=code&query=org%3Aopenstax+ubuntu-20.04+in%3Afile).

I updated CORGI to use a newer version of poetry, but I did not foresee this image being a problem.